### PR TITLE
fix constraint function mixing 1-indexing and 0-indexing.

### DIFF
--- a/Control/Monad/CSP.hs
+++ b/Control/Monad/CSP.hs
@@ -193,7 +193,7 @@ constraint f dvl =
                                                    let loop []     es _ = f (reverse es)
                                                        loop (d:ds) es j | i == j = loop ds (d2e:es) (j + 1)
                                                                         | otherwise = any (\e -> loop ds (e : es) (j + 1)) d
-                                                   in loop ddvl [] 0) d2))
+                                                   in loop ddvl [] 1) d2))
                  $ zip dvl ([1..] :: [Int])))
       $ zip dvl ([1..] :: [Int])
 


### PR DESCRIPTION
Not a lot more to say past the commit; after trying to figure out why I was getting things passed to my test function that were not in the domain of that variable but were in the domain of an adjacent variable, I found that the indexing was mixed up in constraint. This fixes it to be 1-indexed throughout.
